### PR TITLE
fixed solve_chol

### DIFF
--- a/src/Cholesky/Cholesky.jl
+++ b/src/Cholesky/Cholesky.jl
@@ -27,7 +27,7 @@ function solve_chol(L, b)
     y = zeros(BigFloat, n)
 
     for i in 1:n
-        y[i] = b[i] - sum(L[i, 1:i-1] .* y[1:i-1])
+        y[i] = (b[i] - sum(L[i, 1:i-1] .* y[1:i-1])) / L[i, i]
     end
 
     x = zeros(BigFloat, n)


### PR DESCRIPTION
tem que dividir por L[i, i] no cholesky pq diferente do LU a matriz triangular inferior não tem diagonal de 1 obrigatoriamente